### PR TITLE
Switch to a 202 Accepted for incomplete status operations

### DIFF
--- a/Solutions/Marain.Operations.Hosting.AspNetCore/Microsoft/Extensions/DependencyInjection/OperationsServiceCollectionExtensions.cs
+++ b/Solutions/Marain.Operations.Hosting.AspNetCore/Microsoft/Extensions/DependencyInjection/OperationsServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ namespace Marain.Operations.OpenApi
             services.AddOpenApiHttpRequestHosting<SimpleOpenApiContext>((config) =>
             {
                 config.Documents.RegisterOpenApiServiceWithEmbeddedDefinition<OperationsStatusOpenApiService>();
+                OperationsStatusOpenApiService.MapLinks(config.Links);
                 configureHost?.Invoke(config);
             });
 

--- a/Solutions/Marain.Operations.OpenApi/Marain/Operations/OpenApi/OperationsStatus.yaml
+++ b/Solutions/Marain.Operations.OpenApi/Marain/Operations/OpenApi/OperationsStatus.yaml
@@ -28,6 +28,12 @@ paths:
             type: string
             format: uuid
       responses:
+        '202':
+          description: Accepted. The operation is still running, and you should poll again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Operation'
         '200':
           description: OK
           content:

--- a/Solutions/Marain.Operations.Specs/Integration/OperationsStatusApiAndTasks.feature
+++ b/Solutions/Marain.Operations.Specs/Integration/OperationsStatusApiAndTasks.feature
@@ -13,12 +13,18 @@ Scenario: Get non-existent operation
 Scenario: Get not started operation
 	Given There is an operation in the store with id 'd306cb37-bc58-40fc-801c-bce5fb2c3a67' and a status of 'NotStarted'
 	When I call OperationsStatusOpenApiService.GetOperationById with id 'd306cb37-bc58-40fc-801c-bce5fb2c3a67'
-	Then the result status should be 200
+	Then the result status should be 202
     And the operation status in the result should be 'NotStarted'
 
 Scenario: Get running operation
 	Given There is a running operation in the store with id 'd306cb37-bc58-40fc-801c-bce5fb2c3a67' and a percentComplete of 42
 	When I call OperationsStatusOpenApiService.GetOperationById with id 'd306cb37-bc58-40fc-801c-bce5fb2c3a67'
-	Then the result status should be 200
+	Then the result status should be 202
     And the operation status in the result should be 'Running'
     And the percentComplete in the result should be 42
+
+Scenario: Get completed operation
+	Given There is an operation in the store with id 'd306cb37-bc58-40fc-801c-bce5fb2c3a67' and a status of 'Succeeded'
+	When I call OperationsStatusOpenApiService.GetOperationById with id 'd306cb37-bc58-40fc-801c-bce5fb2c3a67'
+	Then the result status should be 200
+    And the operation status in the result should be 'Succeeded'

--- a/Solutions/Marain.Operations.Specs/Integration/OperationsStatusApiAndTasks.feature.cs
+++ b/Solutions/Marain.Operations.Specs/Integration/OperationsStatusApiAndTasks.feature.cs
@@ -110,7 +110,7 @@ this.ScenarioInitialize(scenarioInfo);
  testRunner.When("I call OperationsStatusOpenApiService.GetOperationById with id \'d306cb37-bc58-40f" +
                     "c-801c-bce5fb2c3a67\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line 16
- testRunner.Then("the result status should be 200", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.Then("the result status should be 202", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 17
     testRunner.And("the operation status in the result should be \'NotStarted\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
@@ -132,11 +132,33 @@ this.ScenarioInitialize(scenarioInfo);
  testRunner.When("I call OperationsStatusOpenApiService.GetOperationById with id \'d306cb37-bc58-40f" +
                     "c-801c-bce5fb2c3a67\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line 22
- testRunner.Then("the result status should be 200", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.Then("the result status should be 202", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 23
     testRunner.And("the operation status in the result should be \'Running\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 24
     testRunner.And("the percentComplete in the result should be 42", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Get completed operation")]
+        public virtual void GetCompletedOperation()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get completed operation", null, ((string[])(null)));
+#line 26
+this.ScenarioInitialize(scenarioInfo);
+            this.ScenarioStart();
+#line 27
+ testRunner.Given("There is an operation in the store with id \'d306cb37-bc58-40fc-801c-bce5fb2c3a67\'" +
+                    " and a status of \'Succeeded\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 28
+ testRunner.When("I call OperationsStatusOpenApiService.GetOperationById with id \'d306cb37-bc58-40f" +
+                    "c-801c-bce5fb2c3a67\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 29
+ testRunner.Then("the result status should be 200", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 30
+    testRunner.And("the operation status in the result should be \'Succeeded\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/Solutions/Marain.Operations.Specs/Integration/Steps/OperationsStatusApiAndTasksSteps.cs
+++ b/Solutions/Marain.Operations.Specs/Integration/Steps/OperationsStatusApiAndTasksSteps.cs
@@ -14,6 +14,8 @@ namespace Marain.Operations.Specs.Integration.Steps
     using Marain.Operations.Domain;
     using Marain.Operations.OpenApi;
     using Menes;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.DependencyInjection;
     using NUnit.Framework;
     using TechTalk.SpecFlow;
@@ -23,6 +25,7 @@ namespace Marain.Operations.Specs.Integration.Steps
     {
         private readonly IServiceProvider serviceProvider;
         private readonly FakeOperationsRepository repository;
+        private readonly IOpenApiHost host;
         private readonly ITenantProvider tenantProvider;
         private readonly ScenarioContext scenarioContext;
 
@@ -30,6 +33,7 @@ namespace Marain.Operations.Specs.Integration.Steps
         {
             this.serviceProvider = ContainerBindings.GetServiceProvider(featureContext);
             this.repository = this.serviceProvider.GetRequiredService<FakeOperationsRepository>();
+            this.host = this.serviceProvider.GetRequiredService<IOpenApiHost<HttpRequest, IActionResult>>();
             this.tenantProvider = this.serviceProvider.GetRequiredService<ITenantProvider>();
             this.OperationsTenant = this.tenantProvider.Root;
             this.TenantId = this.OperationsTenant.Id;

--- a/Solutions/Marain.Operations.StatusHost.Functions/Marain/Operations/StatusHost/Startup.cs
+++ b/Solutions/Marain.Operations.StatusHost.Functions/Marain/Operations/StatusHost/Startup.cs
@@ -44,7 +44,10 @@ namespace Marain.Operations.StatusHost
 
             IConfigurationRoot root = Configure(services);
 
-            services.AddTenantedOperationsStatusApi(root, config => config.Documents.AddSwaggerEndpoint());
+            services.AddTenantedOperationsStatusApi(root, config =>
+            {
+                config.Documents.AddSwaggerEndpoint();
+            });
         }
 
         private static IConfigurationRoot Configure(IServiceCollection services)


### PR DESCRIPTION
- Changed the response to return a 202 and a location header for the "not yet completed" state(s)
- Continue to provide a 200 for completed.

We differ from the specification in that we return a body with the 202 to indicate the current status (as per Azure Durable Functions). This is not really ideal, but otherwise you lose the status information.